### PR TITLE
Add variable to configure SSH connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The full path on the remote backup server where backups will be stored (all back
 
 Add the remote host key details to ensure the host key is present and there are no SSH connection errors based on the key authentication. Leave blank if you've disabled host key checking or if the host key is already added to the server via some other mechanism.
 
+    backup_remote_connection_ssh_options: ''
+
+Options to configure SSH connection options such as port (`-p port`). See [SSH manpages](http://man.openbsd.org/ssh) for more options.
+
     backup_mysql: true
     backup_mysql_user: dbdump
     backup_mysql_password: password

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ backup_exclude_items:
 backup_identifier: id_here
 backup_remote_connection: user@backup.example.com
 backup_remote_base_path: "~/backups"
+backup_remote_connection_ssh_options: ''
 
 # Add your server's host key to ensure seamless backup functionality.
 backup_remote_host_name: ''

--- a/templates/backup.sh.j2
+++ b/templates/backup.sh.j2
@@ -13,7 +13,7 @@ RSYNC=/usr/bin/rsync
 
 # Backup individual directories.
 {% for directory in backup_directories %}
-$RSYNC -aqz -e "ssh" --delete --exclude-from '{{ backup_path }}/backup-exclude.txt' {{ directory }} $REMOTE:{{ backup_remote_base_path }}/{{ backup_identifier }}
+$RSYNC -aqz -e 'ssh {{ backup_remote_connection_ssh_options }}' --delete --exclude-from '{{ backup_path }}/backup-exclude.txt' {{ directory }} $REMOTE:{{ backup_remote_base_path }}/{{ backup_identifier }}
 {% endfor %}
 
 {% if backup_mysql %}
@@ -32,5 +32,5 @@ do
 done
 
 # Sync the databases directory.
-$RSYNC -aqz -e "ssh" $HOME/backups/databases $REMOTE:~/backups/{{ backup_identifier }}
+$RSYNC -aqz -e 'ssh {{ backup_remote_connection_ssh_options }}' $HOME/backups/databases $REMOTE:~/backups/{{ backup_identifier }}
 {% endif %}


### PR DESCRIPTION
The idea is to pass "raw" ssh options to allow "advanced" connection configurations.
Use cases could be for example :  to connect a remote host on a non standard port using -p or to specify a specific identity file using -i