### PR TITLE
replace hardcoded paths and backup_home removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ Controls whether the backup script is called via a managed cron job. You should 
 
 User under which backup jobs will run.
 
-    backup_home: /home/{{ backup_user }}
     backup_path: /home/{{ backup_user }}/backups
 
-Home directory and path to where backups configuration will be stored. Generally speaking, you should use a special backup user account, but you can set this to whatever account has the proper access to the directories you need to back up.
+Path to where backups configuration will be stored. Generally speaking, you should use a special backup user account, but you can set this to whatever account has the proper access to the directories you need to back up.
 
     backup_directories:
       - /home/{{ backup_user }}/domains

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,7 @@ backup_minute: "00"
 # User under which backup jobs will run.
 backup_user: "{{ ansible_ssh_user }}"
 
-# Home directory and path to where backups configuration will be stored.
-backup_home: /home/{{ backup_user }}
+# Path to where backups configuration will be stored.
 backup_path: /home/{{ backup_user }}/backups
 
 # Directories to back up. {{ backup_user }} must have read access to these dirs.

--- a/templates/backup.sh.j2
+++ b/templates/backup.sh.j2
@@ -8,7 +8,6 @@
 
 # Common variables.
 REMOTE="{{ backup_remote_connection }}"
-HOME={{ backup_home }}
 RSYNC=/usr/bin/rsync
 
 # Backup individual directories.
@@ -28,9 +27,9 @@ DATABASES=`$MYSQL -u $MYSQL_USER -p$MYSQL_PASS -e "SHOW DATABASES;" | grep -Ev '
 for DB in $DATABASES
 do
   # Dump the database with mysqldump (piped through gzip to conserve IO).
-  $MYSQLDUMP -u $MYSQL_USER -p$MYSQL_PASS --single-transaction --quick --lock-tables=false $DB | gzip -f -6 > $HOME/backups/databases/$DB.sql.gz
+  $MYSQLDUMP -u $MYSQL_USER -p$MYSQL_PASS --single-transaction --quick --lock-tables=false $DB | gzip -f -6 > {{ backup_path }}/databases/$DB.sql.gz
 done
 
 # Sync the databases directory.
-$RSYNC -aqz -e 'ssh {{ backup_remote_connection_ssh_options }}' $HOME/backups/databases $REMOTE:~/backups/{{ backup_identifier }}
+$RSYNC -aqz -e 'ssh {{ backup_remote_connection_ssh_options }}' {{ backup_path }}/databases $REMOTE:{{ backup_remote_base_path }}/{{ backup_identifier }}
 {% endif %}


### PR DESCRIPTION
Some parts of the generated paths were hardcoded.
Replace these paths using backup_path variable.

As backup_home was only used by previously replaced paths this variable has been removed.