### PR TITLE
Add a variable to use an option file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Add SSH connection options (e.g. `-p [port]`), as documented in the [SSH command
     backup_mysql: true
     backup_mysql_user: dbdump
     backup_mysql_password: password
+    backup_mysql_credential_file: ''
 
 Options for backing up MySQL (or MySQL-compatible) databases. Note the `ansible_ssh_user` used when running this role must be able to add MySQL users for this functionality to be managed by this role.
+Instead of creating a new MySQL user account you can provide an existing one using `backup_mysql_credential_file` an option file as documented in the [End-User Guidelines for Password Security](https://dev.mysql.com/doc/refman/5.7/en/password-security-user.html).
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,4 @@ backup_remote_host_key: ''
 backup_mysql: true
 backup_mysql_user: dbdump
 backup_mysql_password: password
+backup_mysql_credential_file: ''

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -17,3 +17,4 @@
     - "127.0.0.1"
     - "::1"
     - "localhost"
+  when: backup_mysql_credential_file == ''

--- a/templates/backup.sh.j2
+++ b/templates/backup.sh.j2
@@ -20,15 +20,17 @@ $RSYNC -aqz -e 'ssh {{ backup_remote_connection_ssh_options }}' --delete --exclu
 # MySQL variables.
 MYSQL=/usr/bin/mysql
 MYSQLDUMP=/usr/bin/mysqldump
-MYSQL_USER={{ backup_mysql_user }}
-MYSQL_PASS={{ backup_mysql_password }}
-
+{% if backup_mysql_credential_file != '' %}
+MYSQL_CREDENTIALS="--defaults-extra-file={{ backup_mysql_credential_file }}"
+{% else %}
+MYSQL_CREDENTIALS= "-u {{ backup_mysql_user }} -p{{ backup_mysql_password }}"
+{% endif %}
 # Dump all MySQL databases.
-DATABASES=`$MYSQL -u $MYSQL_USER -p$MYSQL_PASS -e "SHOW DATABASES;" | grep -Ev '(Database|information_schema|performance_schema|mysql)'`
+DATABASES=`$MYSQL $MYSQL_CREDENTIALS -e "SHOW DATABASES;" | grep -Ev '(Database|information_schema|performance_schema|mysql)'`
 for DB in $DATABASES
 do
   # Dump the database with mysqldump (piped through gzip to conserve IO).
-  $MYSQLDUMP -u $MYSQL_USER -p$MYSQL_PASS --single-transaction --quick --lock-tables=false $DB | gzip -f -6 > $HOME/backups/databases/$DB.sql.gz
+  $MYSQLDUMP $MYSQL_CREDENTIALS --single-transaction --quick --lock-tables=false $DB | gzip -f -6 > $HOME/backups/databases/$DB.sql.gz
 done
 
 # Sync the databases directory.


### PR DESCRIPTION
Allow to manage the MySQL credentials using an option file.

This way we can manage the MySQL account using external tools/scripts/ansible-role (eg: geerlingguy.mysql :))