### PR TITLE
Check remote host and key vars more efficiently

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,14 +25,14 @@ backup_exclude_items:
 backup_identifier: id_here
 backup_remote_connection: user@backup.example.com
 backup_remote_base_path: "~/backups"
-backup_remote_connection_ssh_options: ''
+backup_remote_connection_ssh_options: null
 
 # Add your server's host key to ensure seamless backup functionality.
-backup_remote_host_name: ''
-backup_remote_host_key: ''
+backup_remote_host_name: null
+backup_remote_host_key: null
 
 # MySQL database backup options.
 backup_mysql: true
 backup_mysql_user: dbdump
 backup_mysql_password: password
-backup_mysql_credential_file: ''
+backup_mysql_credential_file: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,8 +38,8 @@
     name: "{{ backup_remote_host_name }}"
     key: "{{ backup_remote_host_name }} {{ backup_remote_host_key }}"
   when:
-    - backup_remote_host_name
-    - backup_remote_host_key
+    - backup_remote_host_name is not none
+    - backup_remote_host_key is not none
 
 - include: databases.yml
   when: backup_mysql


### PR DESCRIPTION
When host looked like host-012.foo, ansible interpreted it like "var host" minus "012.foo"
and killed itself with an error message about ints and properties...